### PR TITLE
Add worker heartbeat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ travis-ci = { repository = "embali/rjq" }
 
 [dependencies]
 error-chain = "0.12"
-redis = "0.8"
-uuid = { version = "0.6", features = ["v4"] }
+redis = "0.9"
+uuid = { version = "0.7.1", features = ["v4"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ description = """Redis job queue"""
 travis-ci = { repository = "embali/rjq" }
 
 [dependencies]
-error-chain = "0.12"
-redis = "0.9"
+error-chain = "0.12.0"
+redis = "0.9.1"
 uuid = { version = "0.7.1", features = ["v4"] }
-serde = "1.0"
-serde_json = "1.0"
-serde_derive = "1.0"
+serde = "1.0.80"
+serde_json = "1.0.33"
+serde_derive = "1.0.80"

--- a/examples/producer.rs
+++ b/examples/producer.rs
@@ -1,8 +1,8 @@
 extern crate rjq;
 
-use std::time::Duration;
-use std::thread::sleep;
 use rjq::Queue;
+use std::thread::sleep;
+use std::time::Duration;
 
 fn main() {
     let queue = Queue::new("redis://localhost/", "rjq");

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -2,9 +2,9 @@
 extern crate error_chain;
 extern crate rjq;
 
-use std::time::Duration;
-use std::thread::sleep;
 use rjq::Queue;
+use std::thread::sleep;
+use std::time::Duration;
 
 mod errors {
     extern crate redis;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,13 +57,13 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate uuid;
 
-use std::thread;
-use std::sync::mpsc::channel;
-use std::time::Duration;
-use std::thread::sleep;
-use std::marker::{Send, Sync};
-use std::sync::Arc;
 use redis::{Client, Commands};
+use std::marker::{Send, Sync};
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use std::thread;
+use std::thread::sleep;
+use std::time::Duration;
 use uuid::Uuid;
 
 pub mod errors {
@@ -217,7 +217,8 @@ impl Queue {
         let conn = self.redis_connection()?;
         let keys: Vec<String> = conn.keys(format!("{}:*", self.name))?;
 
-        let jobs: Vec<Job> = keys.iter()
+        let jobs: Vec<Job> = keys
+            .iter()
             .filter_map(|key| conn.get(format!("{}", key)).ok())
             .filter_map(|json: String| serde_json::from_str(&json).ok())
             .collect();

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -3,9 +3,9 @@
 extern crate error_chain;
 extern crate rjq;
 
-use std::time::Duration;
-use std::thread::sleep;
 use rjq::{Queue, Status};
+use std::thread::sleep;
+use std::time::Duration;
 
 mod errors {
     extern crate redis;
@@ -65,8 +65,7 @@ fn test_job_finished() {
             Some(5),
             Some(false),
             Some(false),
-        )
-        .unwrap();
+        ).unwrap();
 
     let status = queue.status(&uuid).unwrap();
     assert!(status == Status::FINISHED(Some("ok".to_string())));
@@ -92,8 +91,7 @@ fn test_job_result() {
             Some(5),
             Some(false),
             Some(false),
-        )
-        .unwrap();
+        ).unwrap();
 
     let res = queue.result(&uuid).unwrap();
     assert!(res == Some("ok".to_string()));
@@ -119,8 +117,7 @@ fn test_job_failed() {
             Some(5),
             Some(false),
             Some(false),
-        )
-        .unwrap();
+        ).unwrap();
 
     let status = queue.status(&uuid).unwrap();
     assert_eq!(
@@ -152,8 +149,7 @@ fn test_job_lost() {
             Some(5),
             Some(false),
             Some(false),
-        )
-        .unwrap();
+        ).unwrap();
 
     let status = queue.status(&uuid).unwrap();
     assert!(status == Status::LOST);


### PR DESCRIPTION
Right now if a worker process dies (e.g. due to a network partition, host failure, OOM error) we have to wait until the overall job timeout is hit before the job is marked as failed/lost. This is problematic when we have long running jobs with large timeouts, because it could mean waiting hours for a job to be restarted.

Adding proper worker heartbeats is a standard way to solve this (e.g. in [rq][rq], [faktory][faktory], and others) but that's tricky in `rjq` because 'workers' aren't such a first class concept - they're not registered or monitored. In the absence of that, I've implemented a simple version which just reduces the expiry time of the job in Redis significantly, then resets it on every heartbeat until the job is completed, failed, or times out, in which case the expiry time is updated to `expiry` as before.

The bad news here is that if a worker does die unexpectedly, the key in Redis is simply lost, rather than remaining and being marked as `LOST`. I'm not sure there's a way around that without adding a more concrete 'worker' abstraction (which might be worth doing, but will increase complexity).